### PR TITLE
Add input parameter (save_merged) to decide whether to merge paired-e…

### DIFF
--- a/subworkflows/ebi-metagenomics/reads_qc/main.nf
+++ b/subworkflows/ebi-metagenomics/reads_qc/main.nf
@@ -5,13 +5,14 @@ include { SEQTK_SEQ     } from '../../../modules/ebi-metagenomics/seqtk/seq/main
 workflow  READS_QC {
 
     take:
-    ch_reads // channel: [ val(meta), [ fastq ] ]
+    ch_reads    // channel: [ val(meta), [ fastq ] ]
+    save_merged // channel:  val(boolean)
 
     main:
 
     ch_versions = Channel.empty()
 
-    FASTP ( ch_reads, params.save_trimmed_fail, params.save_merged )
+    FASTP ( ch_reads, params.save_trimmed_fail, save_merged )
     ch_versions = ch_versions.mix(FASTP.out.versions.first())
 
     ch_se_fastp_reads = FASTP

--- a/subworkflows/ebi-metagenomics/reads_qc/nextflow.config
+++ b/subworkflows/ebi-metagenomics/reads_qc/nextflow.config
@@ -8,5 +8,4 @@ process {
 params {
 
     save_trimmed_fail = true
-    save_merged = true
 }

--- a/tests/modules/ebi-metagenomics/fastp/main.nf
+++ b/tests/modules/ebi-metagenomics/fastp/main.nf
@@ -15,6 +15,6 @@ workflow test_fastp {
     FASTP (
         input,
         params.save_trimmed_fail,
-        params.save_merged
+        true
      )
 }

--- a/tests/modules/ebi-metagenomics/fastp/main.nf
+++ b/tests/modules/ebi-metagenomics/fastp/main.nf
@@ -15,6 +15,6 @@ workflow test_fastp {
     FASTP (
         input,
         params.save_trimmed_fail,
-        true
+        true // save merged reads
      )
 }

--- a/tests/subworkflows/ebi-metagenomics/reads_qc/main.nf
+++ b/tests/subworkflows/ebi-metagenomics/reads_qc/main.nf
@@ -12,7 +12,7 @@ workflow test_reads_qc_pe {
           file('tests/subworkflows/ebi-metagenomics/reads_qc/data/SRR21814853_2.fastq.gz', checkIfExists: true) ]
     ]
 
-    READS_QC ( input )
+    READS_QC ( input, false )
 }
 
 workflow test_reads_qc_se {
@@ -22,7 +22,7 @@ workflow test_reads_qc_se {
           file('tests/subworkflows/ebi-metagenomics/reads_qc/data/SRR9674626.fastq.gz', checkIfExists: true),
     ]
 
-    READS_QC ( input )
+    READS_QC ( input, false  )
 }
 
 workflow test_reads_qc_pe_and_se {
@@ -35,10 +35,28 @@ workflow test_reads_qc_pe_and_se {
 
     input_se = [
         [ id:'test_se', single_end:true ], // meta map
-          file('tests/subworkflows/ebi-metagenomics/reads_qc/data/SRR9674626.fastq.gz', checkIfExists: true),
+          file('tests/subworkflows/ebi-metagenomics/reads_qc/data/SRR9674626.fastq.gz', checkIfExists: true)
     ]
 
     input_pe_and_se = Channel.from( input_pe, input_se )
 
-    READS_QC ( input_pe_and_se )
+    READS_QC ( input_pe_and_se, false  )
+}
+
+workflow test_save_merged {
+    
+    input_pe = [
+        [ id:'test_pe', single_end:false ], // meta map
+        [ file('tests/subworkflows/ebi-metagenomics/reads_qc/data/SRR21814853_1.fastq.gz', checkIfExists: true),
+          file('tests/subworkflows/ebi-metagenomics/reads_qc/data/SRR21814853_2.fastq.gz', checkIfExists: true) ]
+    ]
+
+    input_se = [
+        [ id:'test_se', single_end:true ], // meta map
+          file('tests/subworkflows/ebi-metagenomics/reads_qc/data/SRR9674626.fastq.gz', checkIfExists: true)
+    ]
+
+    input_pe_and_se = Channel.from( input_pe, input_se )
+
+    READS_QC ( input_pe_and_se, true )
 }

--- a/tests/subworkflows/ebi-metagenomics/reads_qc/nextflow.config
+++ b/tests/subworkflows/ebi-metagenomics/reads_qc/nextflow.config
@@ -10,5 +10,4 @@ process {
 params {
 
     save_trimmed_fail = true
-    save_merged = true
 }

--- a/tests/subworkflows/ebi-metagenomics/reads_qc/test.yml
+++ b/tests/subworkflows/ebi-metagenomics/reads_qc/test.yml
@@ -9,24 +9,20 @@
   files:
     - path: output/fastp/test.fastp.html
       contains:
-        - "1.789477 M (97.392334%)"
+        - "17.225000 M (80.665381%)"
     - path: output/fastp/test.fastp.json
-      md5sum: 552903446c04b38bd8f2f8976119fc42
+      md5sum: 6bc2e2b905bba66b1b7cbb79179eed24
     - path: output/fastp/test.fastp.log
       contains:
         - "Q30 bases: 6864820(64.3075%)"
-    - path: output/fastp/test.merged.fastq.gz
-      md5sum: bc9ed1744b5c680ef2eb4428e9e5f0ef
     - path: output/fastp/test_1.fail.fastq.gz
-      md5sum: 5f8a4ee1f2baee9f8214b4504358a583
+      md5sum: 4cb6831c56aabcfd296e1aec29e80a56
     - path: output/fastp/test_1.fastp.fastq.gz
-      md5sum: 400ca3c0d3e01d1cdd66af6ba51e083c
+      md5sum: 0a00919b818d956f456d84bc49d45b50
     - path: output/fastp/test_2.fail.fastq.gz
-      md5sum: 4f2f1fbc7bac46520a848af89ea87b52
+      md5sum: bcca9941bb8dc03331726aa44fcd4d8e
     - path: output/fastp/test_2.fastp.fastq.gz
-      md5sum: bac3f9e14935b54e09003dcc1843d6e1
-    - path: output/seqtk/test.seqtk-seq.fasta.gz
-      md5sum: afb4460aa8f0bda84dba3244760155a8
+      md5sum: 4941884214f1a283e0a055ebf587ef62
 
 - name: reads_qc test_reads_qc_se
   command: nextflow run ./tests/subworkflows/ebi-metagenomics/reads_qc -entry test_reads_qc_se -c ./tests/config/nextflow.config
@@ -52,6 +48,44 @@
 
 - name: reads_qc test_reads_qc_pe_and_se
   command: nextflow run ./tests/subworkflows/ebi-metagenomics/reads_qc -entry test_reads_qc_pe_and_se -c ./tests/config/nextflow.config
+  tags:
+    - fastp
+    - seqtk
+    - seqtk/seq
+    - subworkflows
+    - subworkflows/reads_qc
+  files:
+    - path: output/fastp/test_pe.fastp.html
+      contains:
+        - "17.225000 M (80.665381%)"
+    - path: output/fastp/test_pe.fastp.json
+      md5sum: c0694236e9dca9c7e1056b939cd78994
+    - path: output/fastp/test_pe.fastp.log
+      contains:
+        - "Q30 bases: 6864820(64.3075%)"
+    - path: output/fastp/test_pe_1.fail.fastq.gz
+      md5sum: 4cb6831c56aabcfd296e1aec29e80a56
+    - path: output/fastp/test_pe_1.fastp.fastq.gz
+      md5sum: 0a00919b818d956f456d84bc49d45b50
+    - path: output/fastp/test_pe_2.fail.fastq.gz
+      md5sum: bcca9941bb8dc03331726aa44fcd4d8e
+    - path: output/fastp/test_pe_2.fastp.fastq.gz
+      md5sum: 4941884214f1a283e0a055ebf587ef62
+    - path: output/fastp/test_se.fastp.fastq.gz
+      md5sum: d43e36bb4dc60ef1b4094731d76fcfa9
+    - path: output/fastp/test_se.fastp.html
+      contains:
+        - "10.034037 M (97.324196%)"
+    - path: output/fastp/test_se.fastp.json
+      md5sum: f6b2cfdf44dd961f0b5117cdfcf95f85
+    - path: output/fastp/test_se.fastp.log
+      contains:
+        - "Q30 bases: 7949076(77.1013%)"
+    - path: output/seqtk/test_se.seqtk-seq.fasta.gz
+      md5sum: a8a5ccd137561b692a92acf4924275f1
+
+- name: reads_qc test_save_merged
+  command: nextflow run ./tests/subworkflows/ebi-metagenomics/reads_qc -entry test_save_merged -c ./tests/config/nextflow.config
   tags:
     - fastp
     - seqtk


### PR DESCRIPTION
…nd files or not, as if you do the _1 and _2 output files only contain reads that couldn't be merged rather than all cleaned _1 and _2 reads