### PR TITLE
Bug/decont bwamem2

### DIFF
--- a/modules/ebi-metagenomics/samtools/bam2fq/main.nf
+++ b/modules/ebi-metagenomics/samtools/bam2fq/main.nf
@@ -29,8 +29,8 @@ process SAMTOOLS_BAM2FQ {
             -@ $task.cpus \\
             -1 ${prefix}_1.fq.gz \\
             -2 ${prefix}_2.fq.gz \\
-            -0 ${prefix}_other.fq.gz \\
-            -s ${prefix}_singleton.fq.gz \\
+            -0 /dev/null \\
+            -s /dev/null \\
             $inputbam
 
         cat <<-END_VERSIONS > versions.yml

--- a/modules/ebi-metagenomics/samtools/bam2fq/main.nf
+++ b/modules/ebi-metagenomics/samtools/bam2fq/main.nf
@@ -11,8 +11,10 @@ process SAMTOOLS_BAM2FQ {
     tuple val(meta), path(inputbam), val(split)
 
     output:
-    tuple val(meta), path("*.fq.gz"), emit: reads
-    path "versions.yml"             , emit: versions
+    tuple val(meta), path("*{_1,_2,_interleaved}.fq.gz"),         emit: reads
+    tuple val(meta), path("*_singleton.fq.gz"),   optional: true, emit: singleton_reads
+    tuple val(meta), path("*_other.fq.gz"),       optional: true, emit: other_reads
+    path "versions.yml",                                          emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -29,8 +31,8 @@ process SAMTOOLS_BAM2FQ {
             -@ $task.cpus \\
             -1 ${prefix}_1.fq.gz \\
             -2 ${prefix}_2.fq.gz \\
-            -0 /dev/null \\
-            -s /dev/null \\
+            -0 ${prefix}_other.fq.gz \\
+            -s ${prefix}_singleton.fq.gz \\
             $inputbam
 
         cat <<-END_VERSIONS > versions.yml

--- a/modules/ebi-metagenomics/samtools/bam2fq/meta.yml
+++ b/modules/ebi-metagenomics/samtools/bam2fq/meta.yml
@@ -21,15 +21,11 @@ input:
       type: file
       description: |
         Sorted BAM file
-  - bai_file:
-      type: file
+  - split:
+      type: boolean
       description: |
-        Index of BAM file
-  - reads:
-      type: file
-      description: |
-        List of input FastQ files of size 1 and 2
-        for single-end and paired-end data, respectively.
+        True or false indicating whether the output
+        is for single or paired-end reads
 
 output:
   - meta:
@@ -40,18 +36,21 @@ output:
   - reads:
       type: file
       description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-  - reads:
+        List of fastq files. Two files for paired-end reads and one file for single-end reads
+  - singleton_reads:
       type: file
       description: |
-        List of fastq files. Two files for paired-end reads and one file for single-end reads
+        Fastq files generated for unpaired paired-end reads
+  - other_reads:
+      type: file
+      description: | 
+        Other fastq files generated for paired-end reads
   - versions:
       type: file
       description: |
         File containing software versions
 
 authors:
-  - "@lescai"
+  - "@EBI-Metagenomics"
 maintainers:
-  - "@lescai"
+  - "@EBI-Metagenomics"

--- a/modules/ebi-metagenomics/samtools/bam2fq/meta.yml
+++ b/modules/ebi-metagenomics/samtools/bam2fq/meta.yml
@@ -43,7 +43,7 @@ output:
         Fastq files generated for unpaired paired-end reads
   - other_reads:
       type: file
-      description: | 
+      description: |
         Other fastq files generated for paired-end reads
   - versions:
       type: file

--- a/subworkflows/ebi-metagenomics/reads_bwamem2_decontamination/meta.yml
+++ b/subworkflows/ebi-metagenomics/reads_bwamem2_decontamination/meta.yml
@@ -45,7 +45,6 @@ output:
       description: |
         A list of decontaminated FastQ files of size 1 or 2
         for single-end and paired-end data, respectively
-      pattern: "*.decont.fq.gz"
   - versions:
       type: file
       description: |

--- a/subworkflows/ebi-metagenomics/reads_bwamem2_decontamination/tests/main.nf.test
+++ b/subworkflows/ebi-metagenomics/reads_bwamem2_decontamination/tests/main.nf.test
@@ -44,9 +44,7 @@ nextflow_workflow {
                 // gzip stores extra information in the header, which makes comparing checksums impossible between operating systems.
                 // that is why we use the sizes of files, and that sort of thing
                 { assert path(workflow.out.decontaminated_reads.get(0).get(1).get(0)).linesGzip.size() == 374028 },
-                { assert path(workflow.out.decontaminated_reads.get(0).get(1).get(1)).linesGzip.size() == 374028 },
-                { assert path(workflow.out.decontaminated_reads.get(0).get(1).get(2)).linesGzip.size() == 0 },
-                { assert path(workflow.out.decontaminated_reads.get(0).get(1).get(3)).linesGzip.size() == 7484 }
+                { assert path(workflow.out.decontaminated_reads.get(0).get(1).get(1)).linesGzip.size() == 374028 }
             )
         }
     }


### PR DESCRIPTION
For decontamination it makes no sense to generate ${prefix}_other.fq.gz and ${prefix}_singleton.fq.gz files for paired-end library layout. Test was updated accordingly.