### PR TITLE
New module/krona/ktimporttext (mostly copied from main nf-core modules repo)

### DIFF
--- a/modules/ebi-metagenomics/krona/ktimporttext/environment.yml
+++ b/modules/ebi-metagenomics/krona/ktimporttext/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "krona_ktimporttext"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "bioconda::krona=2.8.1"

--- a/modules/ebi-metagenomics/krona/ktimporttext/main.nf
+++ b/modules/ebi-metagenomics/krona/ktimporttext/main.nf
@@ -1,0 +1,51 @@
+// This krona/ktimporttext module is copied from the already-existing nf-core module (https://nf-co.re/modules/krona_ktimporttext, https://github.com/nf-core/modules/commit/8fc1d24c710ebe1d5de0f2447ec9439fd3d9d66a)
+// This is because there are not currently any nf-core ways of adding modules from more than one nf-core repo
+// One slight change compared to the original is I've added a stub to this module
+
+process KRONA_KTIMPORTTEXT {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/krona:2.8.1--pl5321hdfd78af_1':
+        'biocontainers/krona:2.8.1--pl5321hdfd78af_1' }"
+
+    input:
+    tuple val(meta), path(report)
+
+    output:
+    tuple val(meta), path ('*.html'), emit: html
+    path "versions.yml"             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    ktImportText  \\
+        $args \\
+        -o ${prefix}.html \\
+        $report
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        krona: \$( echo \$(ktImportText 2>&1) | sed 's/^.*KronaTools //g; s/- ktImportText.*\$//g')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    touch ${prefix}.html
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        krona: \$( echo \$(ktImportText 2>&1) | sed 's/^.*KronaTools //g; s/- ktImportText.*\$//g')
+    END_VERSIONS
+    """
+}

--- a/modules/ebi-metagenomics/krona/ktimporttext/meta.yml
+++ b/modules/ebi-metagenomics/krona/ktimporttext/meta.yml
@@ -17,7 +17,7 @@ tools:
       documentation: http://manpages.ubuntu.com/manpages/impish/man1/ktImportTaxonomy.1.html
       tool_dev_url: https://github.com/marbl/Krona
       doi: 10.1186/1471-2105-12-385
-      licence: [ "https://raw.githubusercontent.com/marbl/Krona/master/KronaTools/LICENSE.txt" ]
+      licence: ["https://raw.githubusercontent.com/marbl/Krona/master/KronaTools/LICENSE.txt"]
 input:
   - meta:
       type: map

--- a/modules/ebi-metagenomics/krona/ktimporttext/meta.yml
+++ b/modules/ebi-metagenomics/krona/ktimporttext/meta.yml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "krona_ktimporttext"
+description: Creates a Krona chart from text files listing quantities and lineages.
+keywords:
+  - plot
+  - taxonomy
+  - interactive
+  - html
+  - visualisation
+  - krona chart
+  - metagenomics
+tools:
+  - krona:
+      description: Krona Tools is a set of scripts to create Krona charts from several Bioinformatics tools as well as from text and XML files.
+      homepage: https://github.com/marbl/Krona/wiki/KronaTools
+      documentation: http://manpages.ubuntu.com/manpages/impish/man1/ktImportTaxonomy.1.html
+      tool_dev_url: https://github.com/marbl/Krona
+      doi: 10.1186/1471-2105-12-385
+      licence: [ "https://raw.githubusercontent.com/marbl/Krona/master/KronaTools/LICENSE.txt" ]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test']
+  - report:
+      type: file
+      description: "Tab-delimited text file. Each line should be a number followed by a list of wedges to contribute to (starting from the highest level). If no wedges are listed (and just a quantity is given), it will contribute to the top level. If the same lineage is listed more than once, the values will be added. Quantities can be omitted if -q is specified. Lines beginning with '#' will be ignored."
+      pattern: "*.{txt}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test' ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - html:
+      type: file
+      description: A html file containing an interactive krona plot.
+      pattern: "*.{html}"
+authors:
+  - "@jianhong"
+  - "@chrisata"
+maintainers:
+  - "@chrisata"

--- a/modules/ebi-metagenomics/krona/ktimporttext/tests/main.nf.test
+++ b/modules/ebi-metagenomics/krona/ktimporttext/tests/main.nf.test
@@ -1,0 +1,66 @@
+// This krona/ktimporttext unit test file is converted to nf-test from an existing pytest test at this commit: https://github.com/nf-core/modules/commit/5e34754d42cd2d5d248ca8673c0a53cdf5624905
+// I have converted it because the standard way of writing nf-core unit tests now is to use nf-test
+// It is otherwise exactly the same unit test
+
+nextflow_process {
+
+    name "Test Process KRONA_KTIMPORTTEXT"
+    script "../main.nf"
+    process "KRONA_KTIMPORTTEXT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "krona"
+    tag "krona/ktimporttext"
+
+    test("test_krona_ktimporttext - multi") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/krona/ktimporttext.txt', checkIfExists: true),                       // krona default test file
+                        file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/sarscov2/metagenome/test_1.kraken2.report.txt', checkIfExists: true), // Kraken2 report file
+                        file('https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/delete_me/krona/kaiju_out4krona.txt', checkIfExists: true)                     // Kaiju output 4 krona
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(path(process.out.get(0).get(0).get(1)).readLines()[0].contains("DOCTYPE html PUBLIC")).match("multi_contains_DOCTYPE_html_PUBLIC") }
+            )
+        }
+
+    }
+
+    test("test_krona_ktimporttext - single") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [
+                        file('http://krona.sourceforge.net/examples/text.txt', checkIfExists: true) // krona default test file
+                    ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(path(process.out.get(0).get(0).get(1)).readLines()[0].contains("DOCTYPE html PUBLIC")).match("single_contains_DOCTYPE_html_PUBLIC") }
+            )
+        }
+
+    }
+
+}

--- a/modules/ebi-metagenomics/krona/ktimporttext/tests/main.nf.test.snap
+++ b/modules/ebi-metagenomics/krona/ktimporttext/tests/main.nf.test.snap
@@ -1,0 +1,22 @@
+{
+    "multi_contains_DOCTYPE_html_PUBLIC": {
+        "content": [
+            true
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-17T11:15:59.756328"
+    },
+    "single_contains_DOCTYPE_html_PUBLIC": {
+        "content": [
+            true
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-04-17T11:16:15.282079"
+    }
+}

--- a/modules/ebi-metagenomics/krona/ktimporttext/tests/tags.yml
+++ b/modules/ebi-metagenomics/krona/ktimporttext/tests/tags.yml
@@ -1,0 +1,2 @@
+krona/ktimporttext:
+  - "modules/ebi-metagenomics/krona/ktimporttext/**"


### PR DESCRIPTION
This is mostly a copy of the existing nf-core krona/ktimporttext module (https://nf-co.re/modules/krona_ktimporttext) so that we can add it to subworkflows. The only changes I made are the following:

- Added a `stub` to the module
- Converted the unit tests from `Pytest` to `nf-test`
- Updated `meta.yml` based on more updated nf-core linting requirements
- Added myself as an author alongside the existing author, and just myself as maintainer