### PR TITLE
Fix reads_qc concat/mix

### DIFF
--- a/subworkflows/ebi-metagenomics/reads_qc/main.nf
+++ b/subworkflows/ebi-metagenomics/reads_qc/main.nf
@@ -19,7 +19,8 @@ workflow  READS_QC {
                         .out.reads
                         .filter { it[0].single_end }
 
-    ch_reads_se_and_merged = ch_se_fastp_reads.concat(FASTP.out.reads_merged)
+    ch_reads_se_and_merged = ch_se_fastp_reads
+                            .mix(FASTP.out.reads_merged)
 
     SEQTK_SEQ(ch_reads_se_and_merged)
     ch_versions = ch_versions.mix(SEQTK_SEQ.out.versions.first())


### PR DESCRIPTION
replace .concat with .mix operator because .concat makes the subworkflow wait for all FASTP runs to be done which slows things down in practice