### PR TITLE
Add goslims subworkflow

### DIFF
--- a/modules/ebi-metagenomics/summarisegoslims/main.nf
+++ b/modules/ebi-metagenomics/summarisegoslims/main.nf
@@ -15,9 +15,9 @@ process SUMMARISEGOSLIMS {
     path go_banding
 
     output:
-    tuple val(meta), path("*_summary"), emit: go_summary
-    tuple val(meta), path("*_slim")   , emit: goslim_summary
-    path "versions.yml"               , emit: versions
+    tuple val(meta), path("*_summary.csv"), emit: go_summary
+    tuple val(meta), path("*_slim.csv")   , emit: goslim_summary
+    path "versions.yml"                   , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -32,6 +32,9 @@ process SUMMARISEGOSLIMS {
         -gaf ${gaf} \\
         -o ${prefix}_summary
 
+    mv ${prefix}_summary ${prefix}_summary.csv
+    mv ${prefix}_summary_slim ${prefix}_summary_slim.csv
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         mgnify-pipelines-toolkit: \$(get_mpt_version)
@@ -41,8 +44,8 @@ process SUMMARISEGOSLIMS {
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    touch ${prefix}_summary
-    touch ${prefix}_summary_slim
+    touch ${prefix}_summary.csv
+    touch ${prefix}_summary_slim.csv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/ebi-metagenomics/summarisegoslims/meta.yml
+++ b/modules/ebi-metagenomics/summarisegoslims/meta.yml
@@ -50,20 +50,20 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*_summary":
+      - "*_summary.csv":
           type: file
           description: CSV file containing the counts for the different GO terms in the InterProScan output.
-          pattern: "*_summary"
+          pattern: "*_summary.csv"
   - goslim_summary:
       - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*_slim":
+      - "*_slim.csv":
           type: file
           description: CSV file containing the counts for the different GO-Slim terms in the InterProScan output.
-          pattern: "*_slim"
+          pattern: "*_slim.csv"
   - versions:
       - "versions.yml":
           type: file

--- a/modules/ebi-metagenomics/summarisegoslims/tests/main.nf.test.snap
+++ b/modules/ebi-metagenomics/summarisegoslims/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary:md5,ddf9aa47da0a848795fffb56d9ac3c96"
+                        "test_summary.csv:md5,ddf9aa47da0a848795fffb56d9ac3c96"
                     ]
                 ],
                 "1": [
@@ -17,7 +17,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary_slim:md5,ce50e0507a12ef0d70bd41b14926c5d5"
+                        "test_summary_slim.csv:md5,ce50e0507a12ef0d70bd41b14926c5d5"
                     ]
                 ],
                 "2": [
@@ -29,7 +29,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary:md5,ddf9aa47da0a848795fffb56d9ac3c96"
+                        "test_summary.csv:md5,ddf9aa47da0a848795fffb56d9ac3c96"
                     ]
                 ],
                 "goslim_summary": [
@@ -38,7 +38,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary_slim:md5,ce50e0507a12ef0d70bd41b14926c5d5"
+                        "test_summary_slim.csv:md5,ce50e0507a12ef0d70bd41b14926c5d5"
                     ]
                 ],
                 "versions": [
@@ -50,7 +50,7 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-27T11:18:05.198568257"
+        "timestamp": "2025-01-28T22:32:00.22627889"
     },
     "summarisegoslims - stub": {
         "content": [
@@ -61,7 +61,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_summary.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "1": [
@@ -70,7 +70,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary_slim:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_summary_slim.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "2": [
@@ -82,7 +82,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_summary.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "goslim_summary": [
@@ -91,7 +91,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary_slim:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test_summary_slim.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
                 "versions": [
@@ -103,6 +103,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-27T11:18:11.207305173"
+        "timestamp": "2025-01-28T22:32:06.80636831"
     }
 }

--- a/subworkflows/ebi-metagenomics/goslim_swf/main.nf
+++ b/subworkflows/ebi-metagenomics/goslim_swf/main.nf
@@ -1,0 +1,42 @@
+
+include { GENERATEGAF           } from '../../../modules/ebi-metagenomics/generategaf/main'
+include { OWLTOOLS              } from '../../../modules/ebi-metagenomics/owltools/main'
+include { SUMMARISEGOSLIMS      } from '../../../modules/ebi-metagenomics/summarisegoslims/main'
+
+workflow GOSLIM_SWF {
+
+    take:
+    ch_ips     // channel: [ val(meta), path(tsv) ]
+    go_obo     // channel: path(obo)
+    goslim_ids // channel: path(txt)
+    go_banding // channel: path(txt)
+
+    main:
+
+    ch_versions = Channel.empty()
+
+
+    GENERATEGAF( ch_ips )
+    ch_versions = ch_versions.mix(GENERATEGAF.out.versions.first())
+
+    OWLTOOLS ( 
+                GENERATEGAF.out.gaf,
+                go_obo,
+                goslim_ids
+    )
+    ch_versions = ch_versions.mix(OWLTOOLS.out.versions.first())
+
+    SUMMARISEGOSLIMS (
+        ch_ips,
+        OWLTOOLS.out.gaf,
+        go_obo,
+        go_banding
+    )
+    ch_versions = ch_versions.mix(SUMMARISEGOSLIMS.out.versions.first())
+
+    emit:
+    go_summary            = SUMMARISEGOSLIMS.out.go_summary     // channel: [ val(meta), path(csv) ]
+    goslim_summary        = SUMMARISEGOSLIMS.out.goslim_summary // channel: [ val(meta), path(csv) ]
+    versions              = ch_versions                         // channel: [ versions.yml ]
+}
+

--- a/subworkflows/ebi-metagenomics/goslim_swf/main.nf
+++ b/subworkflows/ebi-metagenomics/goslim_swf/main.nf
@@ -20,9 +20,9 @@ workflow GOSLIM_SWF {
     ch_versions = ch_versions.mix(GENERATEGAF.out.versions.first())
 
     OWLTOOLS ( 
-                GENERATEGAF.out.gaf,
-                go_obo,
-                goslim_ids
+        GENERATEGAF.out.gaf,
+        go_obo,
+        goslim_ids
     )
     ch_versions = ch_versions.mix(OWLTOOLS.out.versions.first())
 

--- a/subworkflows/ebi-metagenomics/goslim_swf/meta.yml
+++ b/subworkflows/ebi-metagenomics/goslim_swf/meta.yml
@@ -36,13 +36,13 @@ output:
       description: |
         Channel containing GO term counts
         Structure: [ val(meta), path(csv) ]
-      pattern: "*_summary"
+      pattern: "*_summary.csv"
   - goslim_summary:
       type: file
       description: |
         Channel containing GO-slim term counts
         Structure: [ val(meta), path(csv) ]
-      pattern: "*_slim"
+      pattern: "*_slim.csv"
   - versions:
       type: file
       description: |

--- a/subworkflows/ebi-metagenomics/goslim_swf/meta.yml
+++ b/subworkflows/ebi-metagenomics/goslim_swf/meta.yml
@@ -1,0 +1,51 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+name: "goslim_swf"
+## TODO nf-core: Add a description of the subworkflow and list keywords
+description: Sort SAM/BAM/CRAM file
+keywords:
+  - sort
+  - bam
+  - sam
+  - cram
+## TODO nf-core: Add a list of the modules and/or subworkflows used in the subworkflow
+components:
+  - samtools/sort
+  - samtools/index
+## TODO nf-core: List all of the channels used as input with a description and their structure
+input:
+  - ch_bam:
+      type: file
+      description: |
+        The input channel containing the BAM/CRAM/SAM files
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*.{bam/cram/sam}"
+## TODO nf-core: List all of the channels used as output with a descriptions and their structure
+output:
+  - bam:
+      type: file
+      description: |
+        Channel containing BAM files
+        Structure: [ val(meta), path(bam) ]
+      pattern: "*.bam"
+  - bai:
+      type: file
+      description: |
+        Channel containing indexed BAM (BAI) files
+        Structure: [ val(meta), path(bai) ]
+      pattern: "*.bai"
+  - csi:
+      type: file
+      description: |
+        Channel containing CSI files
+        Structure: [ val(meta), path(csi) ]
+      pattern: "*.csi"
+  - versions:
+      type: file
+      description: |
+        File containing software versions
+        Structure: [ path(versions.yml) ]
+      pattern: "versions.yml"
+authors:
+  - "@chrisata"
+maintainers:
+  - "@chrisata"

--- a/subworkflows/ebi-metagenomics/goslim_swf/meta.yml
+++ b/subworkflows/ebi-metagenomics/goslim_swf/meta.yml
@@ -1,44 +1,48 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
 name: "goslim_swf"
-## TODO nf-core: Add a description of the subworkflow and list keywords
-description: Sort SAM/BAM/CRAM file
+description: Get GO term and GO-slim term counts out of an InterProScan .tsv output file
 keywords:
-  - sort
-  - bam
-  - sam
-  - cram
-## TODO nf-core: Add a list of the modules and/or subworkflows used in the subworkflow
+  - GO
+  - GO-slim
+  - interpro
+  - interproscan
+  - owltools
 components:
-  - samtools/sort
-  - samtools/index
-## TODO nf-core: List all of the channels used as input with a description and their structure
+  - generategaf
+  - owltools
+  - summarisegoslims
 input:
-  - ch_bam:
+  - ch_ips:
       type: file
       description: |
-        The input channel containing the BAM/CRAM/SAM files
-        Structure: [ val(meta), path(bam) ]
-      pattern: "*.{bam/cram/sam}"
-## TODO nf-core: List all of the channels used as output with a descriptions and their structure
+        The input channel containing the InterProScan output file
+        Structure: [ val(meta), path(tsv) ]
+      pattern: "*.tsv"
+  - go_obo:
+      type: file
+      description: Gene ontology .OBO file, for example go-basic. Can usually be downloaded here https://geneontology.org/docs/download-ontology/
+      pattern: "*.go"
+  - goslim_ids:
+      type: file
+      description: txt file containing the GO terms that make up the input GO-slim
+      pattern: "*.txt"
+  - go_banding:
+      type: file
+      description: txt file containing the GO terms and descriptions that make up the input GO-slim
+      pattern: "*.txt"
 output:
-  - bam:
+  - go_summary:
       type: file
       description: |
-        Channel containing BAM files
-        Structure: [ val(meta), path(bam) ]
-      pattern: "*.bam"
-  - bai:
+        Channel containing GO term counts
+        Structure: [ val(meta), path(csv) ]
+      pattern: "*_summary"
+  - goslim_summary:
       type: file
       description: |
-        Channel containing indexed BAM (BAI) files
-        Structure: [ val(meta), path(bai) ]
-      pattern: "*.bai"
-  - csi:
-      type: file
-      description: |
-        Channel containing CSI files
-        Structure: [ val(meta), path(csi) ]
-      pattern: "*.csi"
+        Channel containing GO-slim term counts
+        Structure: [ val(meta), path(csv) ]
+      pattern: "*_slim"
   - versions:
       type: file
       description: |

--- a/subworkflows/ebi-metagenomics/goslim_swf/tests/main.nf.test
+++ b/subworkflows/ebi-metagenomics/goslim_swf/tests/main.nf.test
@@ -1,0 +1,39 @@
+
+nextflow_workflow {
+
+    name "Test Subworkflow GOSLIM_SWF"
+    script "../main.nf"
+    workflow "GOSLIM_SWF"
+    config "./nextflow.config"
+
+    tag "subworkflows"
+    tag "subworkflows_ebimetagenomics"
+    tag "subworkflows/goslim_swf"
+    tag "generategaf"
+    tag "owltools"
+    tag "summarisegoslims"
+
+    test("goslim_swf") {
+
+        when {
+            workflow {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file("${baseDir}/modules/ebi-metagenomics/generategaf/tests/ips_out.tsv", checkIfExists: true)
+                ]
+                input[1] = file("${baseDir}/modules/ebi-metagenomics/owltools/tests/go-dummy.obo", checkIfExists: true)
+                input[2] = file("${baseDir}/modules/ebi-metagenomics/owltools/tests/goslim_ids.txt", checkIfExists: true)
+                input[3] = file("${baseDir}/modules/ebi-metagenomics/summarisegoslims/tests/goslim_banding_2024.txt", checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(workflow.out).match()}
+            )
+        }
+    }
+}

--- a/subworkflows/ebi-metagenomics/goslim_swf/tests/main.nf.test.snap
+++ b/subworkflows/ebi-metagenomics/goslim_swf/tests/main.nf.test.snap
@@ -8,7 +8,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary:md5,ddf9aa47da0a848795fffb56d9ac3c96"
+                        "test_summary.csv:md5,ddf9aa47da0a848795fffb56d9ac3c96"
                     ]
                 ],
                 "1": [
@@ -17,7 +17,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary_slim:md5,ce50e0507a12ef0d70bd41b14926c5d5"
+                        "test_summary_slim.csv:md5,ce50e0507a12ef0d70bd41b14926c5d5"
                     ]
                 ],
                 "2": [
@@ -31,7 +31,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary:md5,ddf9aa47da0a848795fffb56d9ac3c96"
+                        "test_summary.csv:md5,ddf9aa47da0a848795fffb56d9ac3c96"
                     ]
                 ],
                 "goslim_summary": [
@@ -40,7 +40,7 @@
                             "id": "test",
                             "single_end": false
                         },
-                        "test_summary_slim:md5,ce50e0507a12ef0d70bd41b14926c5d5"
+                        "test_summary_slim.csv:md5,ce50e0507a12ef0d70bd41b14926c5d5"
                     ]
                 ],
                 "versions": [
@@ -54,6 +54,6 @@
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
         },
-        "timestamp": "2025-01-27T17:09:33.939130884"
+        "timestamp": "2025-01-28T22:32:17.095895573"
     }
 }

--- a/subworkflows/ebi-metagenomics/goslim_swf/tests/main.nf.test.snap
+++ b/subworkflows/ebi-metagenomics/goslim_swf/tests/main.nf.test.snap
@@ -1,0 +1,59 @@
+{
+    "goslim_swf": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_summary:md5,ddf9aa47da0a848795fffb56d9ac3c96"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_summary_slim:md5,ce50e0507a12ef0d70bd41b14926c5d5"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,9803d78712ef1091ff5f785e34209e66",
+                    "versions.yml:md5,db47fe42ea02f1cd3ecc4074727e8972",
+                    "versions.yml:md5,f7674bdfeee9a4d98dbb33e474dd7a68"
+                ],
+                "go_summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_summary:md5,ddf9aa47da0a848795fffb56d9ac3c96"
+                    ]
+                ],
+                "goslim_summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_summary_slim:md5,ce50e0507a12ef0d70bd41b14926c5d5"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9803d78712ef1091ff5f785e34209e66",
+                    "versions.yml:md5,db47fe42ea02f1cd3ecc4074727e8972",
+                    "versions.yml:md5,f7674bdfeee9a4d98dbb33e474dd7a68"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.4"
+        },
+        "timestamp": "2025-01-27T17:09:33.939130884"
+    }
+}

--- a/subworkflows/ebi-metagenomics/goslim_swf/tests/nextflow.config
+++ b/subworkflows/ebi-metagenomics/goslim_swf/tests/nextflow.config
@@ -1,0 +1,7 @@
+process{
+
+    withName: OWLTOOLS {
+        ext.args = '--map2slim'
+    }
+
+}


### PR DESCRIPTION
Make a subworkflow out of the three modules added in https://github.com/EBI-Metagenomics/nf-modules/pull/71 and https://github.com/EBI-Metagenomics/nf-modules/pull/72 for getting GO-slim counts from an InterProScan output .tsv file.