### PR TITLE
braker

### DIFF
--- a/modules/ebi-metagenomics/braker/braker/environment.yml
+++ b/modules/ebi-metagenomics/braker/braker/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - "bioconda::braker3=3.0.8"

--- a/modules/ebi-metagenomics/braker/braker/main.nf
+++ b/modules/ebi-metagenomics/braker/braker/main.nf
@@ -1,0 +1,57 @@
+process BRAKER_BRAKER {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/braker3:3.0.8--hdfd78af_0':
+        'biocontainers/braker3:3.0.8--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(genome)
+    path bam
+    path fa
+    path gff
+
+    output:
+    tuple val(meta), path("${prefix}/*.gtf"), emit: gtf
+    path "versions.yml"                     , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    def accepted_hits = bam ? "--bam ${bam}" : ''
+    def proteins = fa ? "--prot_seq ${fa}" : ''
+    def hints = gff ? "--hints ${gff}" : ''
+    """
+    braker.pl \\
+        $args \\
+        --genome ${genome} \\
+        $accepted_hits \\
+        $proteins \\
+        $hints \\
+        --threads $task.cpus \\
+        --workingdir $prefix
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        braker: \$(echo \$(braker.pl --version) | sed -E 's/[^0-9]*([0-9]+\\.[0-9]+\\.[0-9]+).*/\\1/')
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    mkdir $prefix
+    touch $prefix/${prefix}.gtf
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        braker: \$(echo \$(braker.pl --version) | sed -E 's/[^0-9]*([0-9]+\\.[0-9]+\\.[0-9]+).*/\\1/')
+    END_VERSIONS
+    """
+}

--- a/modules/ebi-metagenomics/braker/braker/meta.yml
+++ b/modules/ebi-metagenomics/braker/braker/meta.yml
@@ -1,7 +1,7 @@
----
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "braker_braker"
-description: BRAKER is a gene prediction pipeline that integrates GeneMark and AUGUSTUS to annotate genomes using RNA-seq and protein evidence.
+description: BRAKER is a gene prediction pipeline that integrates GeneMark and AUGUSTUS
+  to annotate genomes using RNA-seq and protein evidence.
 keywords:
   - gene prediction
   - annotation
@@ -10,12 +10,13 @@ keywords:
   - genome
 tools:
   - "braker":
-      description: "Usage of RNA-seq and protein data in a fully automated pipeline to train and predict highly reliable genes with GeneMark-ETP and AUGUSTUS"
+      description: "Usage of RNA-seq and protein data in a fully automated pipeline\
+        \ to train and predict highly reliable genes with GeneMark-ETP and AUGUSTUS"
       homepage: "https://bioinf.uni-greifswald.de/bioinf/braker/"
       documentation: "https://github.com/Gaius-Augustus/BRAKER"
       tool_dev_url: "https://github.com/Gaius-Augustus/BRAKER"
       doi: "10.1101/gr.278090.123"
-      licence: ['Artistic license']
+      licence: ["Artistic license"]
       identifier: biotools:braker3
 input:
   - - meta:
@@ -41,20 +42,23 @@ input:
         pattern: "*.gff"
 output:
   - gtf:
-    - meta:
-        type: map
-        description: |
-          Groovy Map containing sample information
-          e.g. `[ id:'sample1', single_end:false ]`
-    - "*.gtf":
-        type: file
-        description: Annotated gene set
-        pattern: "*.gtf"
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+          pattern: "*.gtf"
+      - ${prefix}/*.gtf:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+          pattern: "*.gtf"
   - versions:
-    - "versions.yml":
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@vagkaratzas"
 maintainers:

--- a/modules/ebi-metagenomics/braker/braker/meta.yml
+++ b/modules/ebi-metagenomics/braker/braker/meta.yml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "braker_braker"
+description: BRAKER is a gene prediction pipeline that integrates GeneMark and AUGUSTUS to annotate genomes using RNA-seq and protein evidence.
+keywords:
+  - gene prediction
+  - annotation
+  - RNA-seq
+  - protein
+  - genome
+tools:
+  - "braker":
+      description: "Usage of RNA-seq and protein data in a fully automated pipeline to train and predict highly reliable genes with GeneMark-ETP and AUGUSTUS"
+      homepage: "https://bioinf.uni-greifswald.de/bioinf/braker/"
+      documentation: "https://github.com/Gaius-Augustus/BRAKER"
+      tool_dev_url: "https://github.com/Gaius-Augustus/BRAKER"
+      doi: "10.1101/gr.278090.123"
+      licence: ['Artistic license']
+      identifier: biotools:braker3
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - genome:
+        type: file
+        description: Reference genome in FASTA format
+        pattern: "*.{fasta,fna,fa}"
+  - - bam:
+        type: file
+        description: RNA-Seq data
+        pattern: "*.bam"
+  - - fa:
+        type: file
+        description: Protein sequences
+        pattern: "*.{fasta,fa}"
+  - - gff:
+        type: file
+        description: A-priori processed extrinsic evidence
+        pattern: "*.gff"
+output:
+  - gtf:
+    - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1', single_end:false ]`
+    - "*.gtf":
+        type: file
+        description: Annotated gene set
+        pattern: "*.gtf"
+  - versions:
+    - "versions.yml":
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+authors:
+  - "@vagkaratzas"
+maintainers:
+  - "@vagkaratzas"

--- a/modules/ebi-metagenomics/braker/braker/tests/main.nf.test
+++ b/modules/ebi-metagenomics/braker/braker/tests/main.nf.test
@@ -1,0 +1,64 @@
+nextflow_process {
+
+    name "Test Process BRAKER_BRAKER"
+    script "../main.nf"
+    process "BRAKER_BRAKER"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "braker"
+    tag "braker/braker"
+
+    test("sarscov2 - genome - proteome - gtf") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta', checkIfExists: true)
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("sarscov2 - genome - proteome - gtf - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}


### PR DESCRIPTION
Needs to set `--AUGUSTUS_BIN_PATH` and  `--AUGUSTUS_SCRIPTS_PATH` from ext.args.
Sadly the conda environment doesn't come with preinstalled augustus stuff, I think.
So it is impossible atm to send directly to nf-core (or pass the tests I guess).
Should be OK to use in a pipeline though.

To port to nf-core, we would probably need to create an augustus nf-core module first, use it as a setup step and properly set these env variables before calling braker.