### PR TITLE
Adjust the s3fire download module to support not only http but ftp links

### DIFF
--- a/modules/ebi-metagenomics/download_from_fire/resources/usr/bin/s3fire_downloader.py
+++ b/modules/ebi-metagenomics/download_from_fire/resources/usr/bin/s3fire_downloader.py
@@ -9,8 +9,8 @@ from botocore import UNSIGNED
 from botocore.config import Config
 
 FIRE_ENDPOINT: str = "https://hl.fire.sdo.ebi.ac.uk"
-PUBLIC_FTP_PATH: str = "ftp.sra.ebi.ac.uk/vol1/"
-PRIVATE_FTP_PATH: str = "ftp.dcc-private.ebi.ac.uk/vol1/"
+PUBLIC_FTP_PATH: str = "ftp://ftp.sra.ebi.ac.uk/vol1/"
+PRIVATE_FTP_PATH: str = "ftp://ftp.dcc-private.ebi.ac.uk/vol1/"
 PUBLIC_BUCKET: str = "era-public"
 PRIVATE_BUCKET: str = "era-private"
 
@@ -30,7 +30,7 @@ def transform_ftp_to_s3(ftp_path: str) -> tuple[str, str]:
     :raises ValueError: If the FTP path does not match the expected format.
     """
     if ftp_path.startswith("https"):
-        ftp_path = ftp_path.replace("https://", "")
+        ftp_path = ftp_path.replace("https://", "ftp://")
     if ftp_path.startswith(PUBLIC_FTP_PATH):
         s3_key = ftp_path.replace(PUBLIC_FTP_PATH, "")
         logger.info(f"Detected a public file for FTP path: {ftp_path}")


### PR DESCRIPTION
This change is needed to support ftp links in the inputs, otherwise it fails

```
Command error:
  INFO: Starting the file download process...
  Traceback (most recent call last):
    File "/Users/mbc/projects/ebi-metagenomics-assembly-analysis-pipeline/modules/ebi-metagenomics/download_from_fire/resources/usr/bin/s3fire_downloader.py", line 160, in <module>
      main()
      ~~~~^^
    File "/Users/mbc/projects/ebi-metagenomics-assembly-analysis-pipeline/modules/ebi-metagenomics/download_from_fire/resources/usr/bin/s3fire_downloader.py", line 155, in main
      download_files(args.ftp_paths, args.outdir, args.access_key, args.secret_key)
      ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/Users/mbc/projects/ebi-metagenomics-assembly-analysis-pipeline/modules/ebi-metagenomics/download_from_fire/resources/usr/bin/s3fire_downloader.py", line 123, in download_files
      s3_key, bucket = transform_ftp_to_s3(ftp_path)
                       ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
    File "/Users/mbc/projects/ebi-metagenomics-assembly-analysis-pipeline/modules/ebi-metagenomics/download_from_fire/resources/usr/bin/s3fire_downloader.py", line 43, in transform_ftp_to_s3
      raise ValueError(
          f"Invalid FTP path: {ftp_path}. Must start with {PUBLIC_FTP_PATH} or {PRIVATE_FTP_PATH}."
      )
  ValueError: Invalid FTP path: ftp://ftp.sra.ebi.ac.uk/vol1/sequence/ERZ773/ERZ773362/contig.fa.gz. Must start with ftp.sra.ebi.ac.uk/vol1/ or ftp.dcc-private.ebi.ac.uk/vol1/.
```