### PR TITLE
Update EXTRACTCOORDS module

### DIFF
--- a/modules/ebi-metagenomics/extractcoords/environment.yml
+++ b/modules/ebi-metagenomics/extractcoords/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::mgnify-pipelines-toolkit=1.2.10"
+  - "bioconda::mgnify-pipelines-toolkit=1.2.11"

--- a/modules/ebi-metagenomics/extractcoords/environment.yml
+++ b/modules/ebi-metagenomics/extractcoords/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::mgnify-pipelines-toolkit=1.0.1"
+  - "bioconda::mgnify-pipelines-toolkit=1.2.10"

--- a/modules/ebi-metagenomics/extractcoords/main.nf
+++ b/modules/ebi-metagenomics/extractcoords/main.nf
@@ -5,8 +5,8 @@ process EXTRACTCOORDS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mgnify-pipelines-toolkit:1.2.10--pyhdfd78af_0':
-        'biocontainers/mgnify-pipelines-toolkit:1.2.10--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/mgnify-pipelines-toolkit:1.2.11--pyhdfd78af_0':
+        'biocontainers/mgnify-pipelines-toolkit:1.2.11--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(easel_coords_fasta)

--- a/modules/ebi-metagenomics/extractcoords/main.nf
+++ b/modules/ebi-metagenomics/extractcoords/main.nf
@@ -5,21 +5,24 @@ process EXTRACTCOORDS {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mgnify-pipelines-toolkit:1.0.4--pyhdfd78af_0':
-        'biocontainers/mgnify-pipelines-toolkit:1.0.4--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/mgnify-pipelines-toolkit:1.2.10--pyhdfd78af_0':
+        'biocontainers/mgnify-pipelines-toolkit:1.2.10--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(easel_coords_fasta)
     tuple val(meta2), path(matched_seqs_with_coords)
 
     output:
-    tuple val(meta), path("sequence-categorisation/*SSU.fasta")        , optional: true, emit: ssu_fasta
-    tuple val(meta), path("sequence-categorisation/*LSU.fasta")        , optional: true, emit: lsu_fasta
-    tuple val(meta), path("sequence-categorisation/*5S.fasta")         , optional: true, emit: fiveS_fasta
-    tuple val(meta), path("sequence-categorisation/*5_8S.fasta")       , optional: true, emit: five_eightS_fasta
-    tuple val(meta), path("sequence-categorisation/*other_ncRNA.fasta"), optional: true, emit: ncrna_fasta
-    tuple val(meta), path("*concat_SSU_LSU_coords.txt")                , emit: concat_ssu_lsu_coords
-    path "versions.yml"                                                , emit: versions
+    tuple val(meta), path("sequence-categorisation/*SSU.fasta")           , optional: true, emit: ssu_fasta
+    tuple val(meta), path("sequence-categorisation/*LSU.fasta")           , optional: true, emit: lsu_fasta
+    tuple val(meta), path("sequence-categorisation/*rRNA_bacteria*.fasta"), optional: true, emit: rrna_bacteria
+    tuple val(meta), path("sequence-categorisation/*rRNA_archaea*.fasta") , optional: true, emit: rrna_archaea
+    tuple val(meta), path("sequence-categorisation/*rRNA_eukarya*.fasta") , optional: true, emit: eukarya
+    tuple val(meta), path("sequence-categorisation/*5S.fasta")            , optional: true, emit: fiveS_fasta
+    tuple val(meta), path("sequence-categorisation/*5_8S.fasta")          , optional: true, emit: five_eightS_fasta
+    tuple val(meta), path("sequence-categorisation/*other_ncRNA.fasta")   , optional: true, emit: ncrna_fasta
+    tuple val(meta), path("*concat_SSU_LSU_coords.txt")                   , emit: concat_ssu_lsu_coords
+    path "versions.yml"                                                   , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,7 +30,7 @@ process EXTRACTCOORDS {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    get_subunits -i $easel_coords_fasta -n ${prefix}
+    get_subunits -i $easel_coords_fasta -n ${prefix} --separate-subunits-by-models
 
     get_subunits_coords -i $matched_seqs_with_coords -s SSU -l LSU
 

--- a/modules/ebi-metagenomics/extractcoords/main.nf
+++ b/modules/ebi-metagenomics/extractcoords/main.nf
@@ -11,6 +11,7 @@ process EXTRACTCOORDS {
     input:
     tuple val(meta), path(easel_coords_fasta)
     tuple val(meta2), path(matched_seqs_with_coords)
+    val separate_subunits
 
     output:
     tuple val(meta), path("sequence-categorisation/*SSU.fasta")           , optional: true, emit: ssu_fasta
@@ -29,8 +30,9 @@ process EXTRACTCOORDS {
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def separate_subunits_flag = separate_subunits ? "--separate-subunits-by-models" : ""
     """
-    get_subunits -i $easel_coords_fasta -n ${prefix} --separate-subunits-by-models
+    get_subunits -i $easel_coords_fasta -n ${prefix} ${separate_subunits_flag}
 
     get_subunits_coords -i $matched_seqs_with_coords -s SSU -l LSU
 

--- a/modules/ebi-metagenomics/extractcoords/meta.yml
+++ b/modules/ebi-metagenomics/extractcoords/meta.yml
@@ -24,9 +24,10 @@ input:
           e.g. `[ id:'sample1', single_end:false ]`
     - easel_coords_fasta:
         type: file
-        description: Fasta file output from running esl-sfetch to extract sequences
-          by name
+        description: Fasta file output from running esl-sfetch to extract
+          sequences by name
         pattern: "*.fasta"
+        ontologies: []
   - - meta2:
         type: map
         description: |
@@ -34,11 +35,13 @@ input:
           e.g. `[ id:'sample1', single_end:false ]`
     - matched_seqs_with_coords:
         type: file
-        description: Space-separated cmsearchdeoverlap output formatted for use by esl-sfetch
+        description: Space-separated cmsearchdeoverlap output formatted for use by
+          esl-sfetch
         pattern: "*.txt"
+        ontologies: []
 output:
-  - ssu_fasta:
-      - meta:
+  ssu_fasta:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -47,8 +50,9 @@ output:
           type: file
           description: Fasta file containing the SSU sequences
           pattern: "*.fasta"
-  - lsu_fasta:
-      - meta:
+          ontologies: []
+  lsu_fasta:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -57,49 +61,89 @@ output:
           type: file
           description: Fasta file containing the LSU sequences
           pattern: "*.fasta"
-  - fiveS_fasta:
-      - meta:
+          ontologies: []
+  rrna_bacteria:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "sequence-categorisation/*5S.fasta":
+      - sequence-categorisation/*rRNA_bacteria*.fasta:
+          type: file
+          description: Fasta file containing bacterial rRNA
+          pattern: "*.fasta"
+          ontologies: []
+  rrna_archaea:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - sequence-categorisation/*rRNA_archaea*.fasta:
+          type: file
+          description: Fasta file containing archaeal rRNA
+          pattern: "*.fasta"
+          ontologies: []
+  eukarya:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - sequence-categorisation/*rRNA_eukarya*.fasta:
+          type: file
+          description: Fasta file containing eukaryan rRNA
+          pattern: "*.fasta"
+          ontologies: []
+  fiveS_fasta:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1', single_end:false ]`
+      - sequence-categorisation/*5S.fasta:
           type: file
           description: "5S rRNA nucleotide sequences"
-  - five_eightS_fasta:
-      - meta:
+          ontologies: []
+  five_eightS_fasta:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "sequence-categorisation/*5_8S.fasta":
+      - sequence-categorisation/*5_8S.fasta:
           type: file
           description: "5 and 8S rRNA nucleotide sequences"
-  - ncrna_fasta:
-      - meta:
+          ontologies: []
+  ncrna_fasta:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "sequence-categorisation/*other_ncRNA.fasta":
+      - sequence-categorisation/*other_ncRNA.fasta:
           type: file
           description: "non-coding RNA nucleotide sequences"
-  - concat_ssu_lsu_coords:
-      - meta:
+          ontologies: []
+  concat_ssu_lsu_coords:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
       - "*concat_SSU_LSU_coords.txt":
           type: file
-          description: Space-separated concatenated file of coordinates of matches of
-            both SSU and LSU
+          description: Space-separated concatenated file of coordinates of matches
+            of both SSU and LSU
           pattern: "*.txt"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@chrisata"
 maintainers:

--- a/modules/ebi-metagenomics/extractcoords/meta.yml
+++ b/modules/ebi-metagenomics/extractcoords/meta.yml
@@ -39,6 +39,9 @@ input:
           esl-sfetch
         pattern: "*.txt"
         ontologies: []
+  - - separate_subunits:
+        type: boolean
+        description: Specify true to separate hits into the different RNA subunits
 output:
   - ssu_fasta:
       - meta:

--- a/modules/ebi-metagenomics/extractcoords/meta.yml
+++ b/modules/ebi-metagenomics/extractcoords/meta.yml
@@ -40,8 +40,8 @@ input:
         pattern: "*.txt"
         ontologies: []
 output:
-  ssu_fasta:
-    - - meta:
+  - ssu_fasta:
+      - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -51,8 +51,8 @@ output:
           description: Fasta file containing the SSU sequences
           pattern: "*.fasta"
           ontologies: []
-  lsu_fasta:
-    - - meta:
+  - lsu_fasta:
+      - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -62,8 +62,8 @@ output:
           description: Fasta file containing the LSU sequences
           pattern: "*.fasta"
           ontologies: []
-  rrna_bacteria:
-    - - meta:
+  - rrna_bacteria:
+      - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -73,8 +73,8 @@ output:
           description: Fasta file containing bacterial rRNA
           pattern: "*.fasta"
           ontologies: []
-  rrna_archaea:
-    - - meta:
+  - rrna_archaea:
+      - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -84,8 +84,8 @@ output:
           description: Fasta file containing archaeal rRNA
           pattern: "*.fasta"
           ontologies: []
-  eukarya:
-    - - meta:
+  - eukarya:
+      - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -95,8 +95,8 @@ output:
           description: Fasta file containing eukaryan rRNA
           pattern: "*.fasta"
           ontologies: []
-  fiveS_fasta:
-    - - meta:
+  - fiveS_fasta:
+      - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -105,8 +105,8 @@ output:
           type: file
           description: "5S rRNA nucleotide sequences"
           ontologies: []
-  five_eightS_fasta:
-    - - meta:
+  - five_eightS_fasta:
+      - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -115,8 +115,8 @@ output:
           type: file
           description: "5 and 8S rRNA nucleotide sequences"
           ontologies: []
-  ncrna_fasta:
-    - - meta:
+  - ncrna_fasta:
+      - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -125,8 +125,8 @@ output:
           type: file
           description: "non-coding RNA nucleotide sequences"
           ontologies: []
-  concat_ssu_lsu_coords:
-    - - meta:
+  - concat_ssu_lsu_coords:
+      - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -137,13 +137,13 @@ output:
             of both SSU and LSU
           pattern: "*.txt"
           ontologies: []
-  versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+          ontologies:
+            - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@chrisata"
 maintainers:

--- a/modules/ebi-metagenomics/extractcoords/tests/main.nf.test
+++ b/modules/ebi-metagenomics/extractcoords/tests/main.nf.test
@@ -22,6 +22,34 @@ nextflow_process {
                     [ id:'test', single_end:false ], // meta map
                     file("${moduleDir}/tests/test_matched_seqs_with_coords.txt", checkIfExists: true),
                 ]
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("extractcoords - test it without splitting subunits") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file("${moduleDir}/tests/test.fasta", checkIfExists: true)
+                ]
+                input[1] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file("${moduleDir}/tests/test_matched_seqs_with_coords.txt", checkIfExists: true),
+                ]
+                input[2] = []
                 """
             }
         }
@@ -50,6 +78,7 @@ nextflow_process {
                     [ id:'test', single_end:false ], // meta map
                     file("${moduleDir}/tests/test_matched_seqs_with_coords.txt", checkIfExists: true),
                 ]
+                input[2] = true
                 """
             }
         }

--- a/modules/ebi-metagenomics/extractcoords/tests/main.nf.test.snap
+++ b/modules/ebi-metagenomics/extractcoords/tests/main.nf.test.snap
@@ -36,7 +36,7 @@
                     ]
                 ],
                 "9": [
-                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
+                    "versions.yml:md5,65ce15e3974d0d71dd42fd5b93a782c1"
                 ],
                 "concat_ssu_lsu_coords": [
                     [
@@ -72,7 +72,7 @@
                     
                 ],
                 "versions": [
-                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
+                    "versions.yml:md5,65ce15e3974d0d71dd42fd5b93a782c1"
                 ]
             }
         ],
@@ -80,7 +80,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-02T13:32:06.364276"
+        "timestamp": "2025-10-06T09:16:25.655571"
     },
     "extractcoords - should take a fasta file and an easel coordinates file and extract two subunit fasta files for the SSU and LSU, and a concatenated SSU and LSU coordinates file": {
         "content": [
@@ -131,7 +131,7 @@
                     ]
                 ],
                 "9": [
-                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
+                    "versions.yml:md5,65ce15e3974d0d71dd42fd5b93a782c1"
                 ],
                 "concat_ssu_lsu_coords": [
                     [
@@ -179,7 +179,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
+                    "versions.yml:md5,65ce15e3974d0d71dd42fd5b93a782c1"
                 ]
             }
         ],
@@ -187,7 +187,7 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-02T15:56:38.551207"
+        "timestamp": "2025-10-06T09:16:06.829993"
     },
     "extractcoords - test it without splitting subunits": {
         "content": [
@@ -232,7 +232,7 @@
                     ]
                 ],
                 "9": [
-                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
+                    "versions.yml:md5,65ce15e3974d0d71dd42fd5b93a782c1"
                 ],
                 "concat_ssu_lsu_coords": [
                     [
@@ -274,7 +274,7 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
+                    "versions.yml:md5,65ce15e3974d0d71dd42fd5b93a782c1"
                 ]
             }
         ],
@@ -282,6 +282,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-02T16:05:06.733373"
+        "timestamp": "2025-10-06T09:16:17.034975"
     }
 }

--- a/modules/ebi-metagenomics/extractcoords/tests/main.nf.test.snap
+++ b/modules/ebi-metagenomics/extractcoords/tests/main.nf.test.snap
@@ -187,6 +187,101 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-02T13:35:56.089528"
+        "timestamp": "2025-10-02T15:56:38.551207"
+    },
+    "extractcoords - test it without splitting subunits": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_SSU.fasta:md5,fb23f13526672a300845b767dbc5fd44"
+                    ]
+                ],
+                "1": [
+                    
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    
+                ],
+                "8": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_concat_SSU_LSU_coords.txt:md5,401222d263116bb145c1a67e6acc4709"
+                    ]
+                ],
+                "9": [
+                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
+                ],
+                "concat_ssu_lsu_coords": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_concat_SSU_LSU_coords.txt:md5,401222d263116bb145c1a67e6acc4709"
+                    ]
+                ],
+                "eukarya": [
+                    
+                ],
+                "fiveS_fasta": [
+                    
+                ],
+                "five_eightS_fasta": [
+                    
+                ],
+                "lsu_fasta": [
+                    
+                ],
+                "ncrna_fasta": [
+                    
+                ],
+                "rrna_archaea": [
+                    
+                ],
+                "rrna_bacteria": [
+                    
+                ],
+                "ssu_fasta": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_SSU.fasta:md5,fb23f13526672a300845b767dbc5fd44"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.04.7"
+        },
+        "timestamp": "2025-10-02T16:05:06.733373"
     }
 }

--- a/modules/ebi-metagenomics/extractcoords/tests/main.nf.test.snap
+++ b/modules/ebi-metagenomics/extractcoords/tests/main.nf.test.snap
@@ -18,6 +18,15 @@
                     
                 ],
                 "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    
+                ],
+                "8": [
                     [
                         {
                             "id": "test",
@@ -26,8 +35,8 @@
                         "test_concat_SSU_LSU_coords.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "6": [
-                    "versions.yml:md5,bb5f83b342f1c323c38cca2eaa5cc866"
+                "9": [
+                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
                 ],
                 "concat_ssu_lsu_coords": [
                     [
@@ -37,6 +46,9 @@
                         },
                         "test_concat_SSU_LSU_coords.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
+                ],
+                "eukarya": [
+                    
                 ],
                 "fiveS_fasta": [
                     
@@ -50,19 +62,25 @@
                 "ncrna_fasta": [
                     
                 ],
+                "rrna_archaea": [
+                    
+                ],
+                "rrna_bacteria": [
+                    
+                ],
                 "ssu_fasta": [
                     
                 ],
                 "versions": [
-                    "versions.yml:md5,bb5f83b342f1c323c38cca2eaa5cc866"
+                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-04-02T08:00:15.899583"
+        "timestamp": "2025-10-02T13:32:06.364276"
     },
     "extractcoords - should take a fasta file and an easel coordinates file and extract two subunit fasta files for the SSU and LSU, and a concatenated SSU and LSU coordinates file": {
         "content": [
@@ -86,9 +104,24 @@
                     
                 ],
                 "4": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_SSU_rRNA_eukarya.RF01960.fasta:md5,fb23f13526672a300845b767dbc5fd44"
+                    ]
                 ],
                 "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    
+                ],
+                "8": [
                     [
                         {
                             "id": "test",
@@ -97,8 +130,8 @@
                         "test_concat_SSU_LSU_coords.txt:md5,401222d263116bb145c1a67e6acc4709"
                     ]
                 ],
-                "6": [
-                    "versions.yml:md5,bb5f83b342f1c323c38cca2eaa5cc866"
+                "9": [
+                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
                 ],
                 "concat_ssu_lsu_coords": [
                     [
@@ -107,6 +140,15 @@
                             "single_end": false
                         },
                         "test_concat_SSU_LSU_coords.txt:md5,401222d263116bb145c1a67e6acc4709"
+                    ]
+                ],
+                "eukarya": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test_SSU_rRNA_eukarya.RF01960.fasta:md5,fb23f13526672a300845b767dbc5fd44"
                     ]
                 ],
                 "fiveS_fasta": [
@@ -121,6 +163,12 @@
                 "ncrna_fasta": [
                     
                 ],
+                "rrna_archaea": [
+                    
+                ],
+                "rrna_bacteria": [
+                    
+                ],
                 "ssu_fasta": [
                     [
                         {
@@ -131,14 +179,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,bb5f83b342f1c323c38cca2eaa5cc866"
+                    "versions.yml:md5,3e0141a2d5d8654800d0ef6cd1556f8e"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-04-02T08:00:12.815188"
+        "timestamp": "2025-10-02T13:35:56.089528"
     }
 }

--- a/subworkflows/ebi-metagenomics/rrna_extraction/main.nf
+++ b/subworkflows/ebi-metagenomics/rrna_extraction/main.nf
@@ -38,7 +38,7 @@ workflow RRNA_EXTRACTION {
     EXTRACTCOORDS(
         EASEL_ESLSFETCH.out.easel_coords,
         EASEL_ESLSFETCH.out.matched_seqs_with_coords,
-        []
+        false
     )
     ch_versions = ch_versions.mix(EXTRACTCOORDS.out.versions.first())
 

--- a/subworkflows/ebi-metagenomics/rrna_extraction/main.nf
+++ b/subworkflows/ebi-metagenomics/rrna_extraction/main.nf
@@ -37,7 +37,8 @@ workflow RRNA_EXTRACTION {
 
     EXTRACTCOORDS(
         EASEL_ESLSFETCH.out.easel_coords,
-        EASEL_ESLSFETCH.out.matched_seqs_with_coords
+        EASEL_ESLSFETCH.out.matched_seqs_with_coords,
+        []
     )
     ch_versions = ch_versions.mix(EXTRACTCOORDS.out.versions.first())
 

--- a/subworkflows/ebi-metagenomics/rrna_extraction/tests/main.nf.test.snap
+++ b/subworkflows/ebi-metagenomics/rrna_extraction/tests/main.nf.test.snap
@@ -44,8 +44,8 @@
                 "5": [
                     "versions.yml:md5,1cd8a1b942aaba58bd5d6ab9c4f3f9b2",
                     "versions.yml:md5,986b50b86874f29db48120870f7ac4f6",
-                    "versions.yml:md5,d1294ff919ea50bc3a41ddc5a88ab3de",
-                    "versions.yml:md5,f01779f5607038292a11e43f5ff23bb8"
+                    "versions.yml:md5,a83addcfaf303617fdda5c6a5958a5ad",
+                    "versions.yml:md5,d1294ff919ea50bc3a41ddc5a88ab3de"
                 ],
                 "cmsearch_deoverlap_out": [
                     [
@@ -89,8 +89,8 @@
                 "versions": [
                     "versions.yml:md5,1cd8a1b942aaba58bd5d6ab9c4f3f9b2",
                     "versions.yml:md5,986b50b86874f29db48120870f7ac4f6",
-                    "versions.yml:md5,d1294ff919ea50bc3a41ddc5a88ab3de",
-                    "versions.yml:md5,f01779f5607038292a11e43f5ff23bb8"
+                    "versions.yml:md5,a83addcfaf303617fdda5c6a5958a5ad",
+                    "versions.yml:md5,d1294ff919ea50bc3a41ddc5a88ab3de"
                 ]
             }
         ],
@@ -98,6 +98,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.7"
         },
-        "timestamp": "2025-10-02T13:32:19.729251"
+        "timestamp": "2025-10-06T09:16:39.686196"
     }
 }

--- a/subworkflows/ebi-metagenomics/rrna_extraction/tests/main.nf.test.snap
+++ b/subworkflows/ebi-metagenomics/rrna_extraction/tests/main.nf.test.snap
@@ -43,9 +43,9 @@
                 ],
                 "5": [
                     "versions.yml:md5,1cd8a1b942aaba58bd5d6ab9c4f3f9b2",
-                    "versions.yml:md5,22f1e076b3392790a82533f83d4e0721",
                     "versions.yml:md5,986b50b86874f29db48120870f7ac4f6",
-                    "versions.yml:md5,d1294ff919ea50bc3a41ddc5a88ab3de"
+                    "versions.yml:md5,d1294ff919ea50bc3a41ddc5a88ab3de",
+                    "versions.yml:md5,f01779f5607038292a11e43f5ff23bb8"
                 ],
                 "cmsearch_deoverlap_out": [
                     [
@@ -88,16 +88,16 @@
                 ],
                 "versions": [
                     "versions.yml:md5,1cd8a1b942aaba58bd5d6ab9c4f3f9b2",
-                    "versions.yml:md5,22f1e076b3392790a82533f83d4e0721",
                     "versions.yml:md5,986b50b86874f29db48120870f7ac4f6",
-                    "versions.yml:md5,d1294ff919ea50bc3a41ddc5a88ab3de"
+                    "versions.yml:md5,d1294ff919ea50bc3a41ddc5a88ab3de",
+                    "versions.yml:md5,f01779f5607038292a11e43f5ff23bb8"
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.04.7"
         },
-        "timestamp": "2025-04-02T08:00:21.792399"
+        "timestamp": "2025-10-02T13:32:19.729251"
     }
 }


### PR DESCRIPTION
Things were a bit of out sync with the EXTRACTCOORDS module in a couple places (amplicon/assembly analysis pipelines), updating it in nf-modules so that we can reset the status of this module again

I'm also unsure whether `--separate-subunits-by-models` should be a default flag or not. It will be used in the amplicon-pipeline but not sure about assembly