### PR TITLE
Modify sam flag in bwamem2decontnobams for paired reads

### DIFF
--- a/modules/ebi-metagenomics/bwamem2decontnobams/main.nf
+++ b/modules/ebi-metagenomics/bwamem2decontnobams/main.nf
@@ -42,7 +42,7 @@ process BWAMEM2DECONTNOBAMS {
             -t $task.cpus \\
             \$INDEX \\
             $reads \\
-            | samtools view -@ ${task.cpus} -f 4 -F 256 -uS - \\
+            | samtools view -@ ${task.cpus} -f 12 -F 256 -uS - \\
             | samtools sort -@ ${task.cpus} -n -O bam - \\
             | samtools bam2fq -@ ${task.cpus} -1 ${ref_prefix}_${prefix}_1.fq.gz -2 ${ref_prefix}_${prefix}_2.fq.gz -0 /dev/null -s /dev/null
     fi


### PR DESCRIPTION
`-f 4` keeps only unmapped reads but ignores the pair (read1 unmapped)
`-f 12` keeps reads only if both it and its pair are unmapped (read1 unmapped + read2 unmapped)

For paired reads we want to remove them if either of the reads in the pair map to the decontamination genome, so we need to change the flag to `-f 12`.