### PR TITLE
Restore old way of emitting versions alongside new way

### DIFF
--- a/modules/ebi-metagenomics/bbmap/reformat/main.nf
+++ b/modules/ebi-metagenomics/bbmap/reformat/main.nf
@@ -14,6 +14,7 @@ process BBMAP_REFORMAT {
     output:
     tuple val(meta), path("*_reformated.${out_fmt}")                                             , emit: reformated
     tuple val("${task.process}"), val('bbmap'), eval('bbversion.sh | grep -v "Duplicate cpuset"'), emit: versions_bbmap, topic: versions
+    path  "versions.yml"                                                                         , emit: versions
     path  "*.log"                                                                                , emit: log
 
     when:
@@ -34,6 +35,11 @@ process BBMAP_REFORMAT {
         threads=${task.cpus} \\
         ${args} \\
         &> ${prefix}.reformat.sh.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
+    END_VERSIONS
     """
 
     stub:
@@ -41,5 +47,10 @@ process BBMAP_REFORMAT {
     """
     echo "" | gzip > ${prefix}_reformated.${out_fmt}
     touch ${prefix}.reformat.sh.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
+    END_VERSIONS
     """
 }

--- a/modules/ebi-metagenomics/bbmap/reformat_standardise/main.nf
+++ b/modules/ebi-metagenomics/bbmap/reformat_standardise/main.nf
@@ -16,6 +16,7 @@ process BBMAP_REFORMAT_STANDARDISE {
     tuple val(meta), path("*_reformated.${out_fmt}")                                             , emit: reformated
     tuple val(meta), path("${prefix}_singleton.${out_fmt}")                                      , optional: true, emit: singleton
     tuple val("${task.process}"), val('bbmap'), eval('bbversion.sh | grep -v "Duplicate cpuset"'), emit: versions_bbmap, topic: versions
+    path  "versions.yml"                                                                         , emit: versions
     path  "*.log"                                                                                , emit: log
 
     when:
@@ -42,6 +43,11 @@ process BBMAP_REFORMAT_STANDARDISE {
         threads=${task.cpus} \\
         ${args} \\
         &> ${prefix}.reformat.sh.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
+    END_VERSIONS
     """
 
     stub:
@@ -51,5 +57,10 @@ process BBMAP_REFORMAT_STANDARDISE {
     echo "" | gzip > ${prefix}_2_reformated.${out_fmt}
     echo "" | gzip > ${prefix}_singleton.${out_fmt}
     touch ${prefix}.reformat.sh.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bbmap: \$(bbversion.sh | grep -v "Duplicate cpuset")
+    END_VERSIONS
     """
 }


### PR DESCRIPTION
This is needed to be compatible with other modules in out pipelines