### PR TITLE
Update ummarisegoslims and generategaf to version 1.5.3 of the toolkit

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -54,7 +54,7 @@ jobs:
 
     env:
       NXF_ANSI_LOG: false
-      NFTEST_VER: "0.9.0"
+      NFTEST_VER: "0.9.5"
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/modules/ebi-metagenomics/generategaf/main.nf
+++ b/modules/ebi-metagenomics/generategaf/main.nf
@@ -4,9 +4,7 @@ process GENERATEGAF {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mgnify-pipelines-toolkit:0.2.0--pyhdfd78af_0':
-        'biocontainers/mgnify-pipelines-toolkit:0.2.0--pyhdfd78af_0' }"
+    container "microbiome-informatics/mgnify-pipelines-toolkit:1.5.3"
 
     input:
     tuple val(meta), path(ips)

--- a/modules/ebi-metagenomics/generategaf/tests/main.nf.test.snap
+++ b/modules/ebi-metagenomics/generategaf/tests/main.nf.test.snap
@@ -3,31 +3,31 @@
         "content": [
             true
         ],
+        "timestamp": "2025-01-27T10:37:05.471621383",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
-        },
-        "timestamp": "2025-01-27T10:37:05.471621383"
+        }
     },
     "gaf_test_2": {
         "content": [
             true
         ],
+        "timestamp": "2025-01-27T10:37:05.448280559",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
-        },
-        "timestamp": "2025-01-27T10:37:05.448280559"
+        }
     },
     "gaf_test_1": {
         "content": [
             true
         ],
+        "timestamp": "2025-01-27T10:37:05.426270774",
         "meta": {
             "nf-test": "0.9.2",
             "nextflow": "24.10.4"
-        },
-        "timestamp": "2025-01-27T10:37:05.426270774"
+        }
     },
     "generategaf - stub": {
         "content": [
@@ -42,7 +42,7 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,53ff6fdbb93140587a50a5ed8aa4aa8f"
+                    "versions.yml:md5,1a2942c3cb20e899ed47c31084d31679"
                 ],
                 "gaf": [
                     [
@@ -54,14 +54,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,53ff6fdbb93140587a50a5ed8aa4aa8f"
+                    "versions.yml:md5,1a2942c3cb20e899ed47c31084d31679"
                 ]
             }
         ],
+        "timestamp": "2026-07-10T15:39:05.213949",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
-        },
-        "timestamp": "2025-01-27T10:37:11.463914247"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }

--- a/modules/ebi-metagenomics/mgnifypipelinestoolkit/summarisegoslims/main.nf
+++ b/modules/ebi-metagenomics/mgnifypipelinestoolkit/summarisegoslims/main.nf
@@ -3,9 +3,7 @@ process MGNIFYPIPELINESTOOLKIT_SUMMARISEGOSLIMS {
     tag "$meta.id"
     label 'process_single'
 
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mgnify-pipelines-toolkit:1.4.13--pyhdfd78af_0':
-        'biocontainers/mgnify-pipelines-toolkit:1.4.13--pyhdfd78af_0' }"
+    container "microbiome-informatics/mgnify-pipelines-toolkit:1.5.3"
 
     input:
     tuple val(meta), path(interproscan_tsv)
@@ -24,16 +22,12 @@ process MGNIFYPIPELINESTOOLKIT_SUMMARISEGOSLIMS {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     def args = task.ext.args ?: ''
-    def interproscan_tsv_file = interproscan_tsv.name.replace(".gz", "")
     """
-    if [ "${interproscan_tsv.name.endsWith(".gz")}" == "true" ]; then
-        gzip -c -d $interproscan_tsv > $interproscan_tsv_file
-    fi
     summarise_goslims \\
         ${args} \\
         -go ${go_obo} \\
         -gb ${go_banding} \\
-        -i ${interproscan_tsv_file} \\
+        -i ${interproscan_tsv} \\
         -gaf ${gaf} \\
         -o ${prefix}_summary
 

--- a/modules/ebi-metagenomics/mgnifypipelinestoolkit/summarisegoslims/tests/main.nf.test.snap
+++ b/modules/ebi-metagenomics/mgnifypipelinestoolkit/summarisegoslims/tests/main.nf.test.snap
@@ -21,7 +21,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,6db230acf2544cacf47be7e240c4dfed"
+                    "versions.yml:md5,5d476cb39e35c0120bdc2d5c03999771"
                 ],
                 "go_summary": [
                     [
@@ -42,15 +42,15 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,6db230acf2544cacf47be7e240c4dfed"
+                    "versions.yml:md5,5d476cb39e35c0120bdc2d5c03999771"
                 ]
             }
         ],
+        "timestamp": "2026-07-10T15:42:08.107457",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T10:12:58.656674"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     },
     "summarise gos with interproscan tsv - stub": {
         "content": [
@@ -74,7 +74,7 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,6db230acf2544cacf47be7e240c4dfed"
+                    "versions.yml:md5,5d476cb39e35c0120bdc2d5c03999771"
                 ],
                 "go_summary": [
                     [
@@ -95,14 +95,14 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,6db230acf2544cacf47be7e240c4dfed"
+                    "versions.yml:md5,5d476cb39e35c0120bdc2d5c03999771"
                 ]
             }
         ],
+        "timestamp": "2026-07-10T15:42:11.34532",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T10:13:01.829257"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }

--- a/subworkflows/ebi-metagenomics/goslim_swf/tests/main.nf.test.snap
+++ b/subworkflows/ebi-metagenomics/goslim_swf/tests/main.nf.test.snap
@@ -21,8 +21,8 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,6ce30e87e756d3d5088573d205edf850",
-                    "versions.yml:md5,9803d78712ef1091ff5f785e34209e66",
+                    "versions.yml:md5,0323ab46c987d80493636b8a432b9820",
+                    "versions.yml:md5,f6e2866f09ba01e338afa2498db3a12e",
                     "versions.yml:md5,f7674bdfeee9a4d98dbb33e474dd7a68"
                 ],
                 "go_summary": [
@@ -44,16 +44,16 @@
                     ]
                 ],
                 "versions": [
-                    "versions.yml:md5,6ce30e87e756d3d5088573d205edf850",
-                    "versions.yml:md5,9803d78712ef1091ff5f785e34209e66",
+                    "versions.yml:md5,0323ab46c987d80493636b8a432b9820",
+                    "versions.yml:md5,f6e2866f09ba01e338afa2498db3a12e",
                     "versions.yml:md5,f7674bdfeee9a4d98dbb33e474dd7a68"
                 ]
             }
         ],
+        "timestamp": "2026-07-10T15:39:15.908154",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-01-21T10:14:32.368692"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }


### PR DESCRIPTION
Updated some modules to use 1.5.3 of the toolkit, less bloat on the fs because we avoid to gunzip fat IPS TSV files.